### PR TITLE
Report callback-calling errors better

### DIFF
--- a/laituri/docker/credential_manager/errors.py
+++ b/laituri/docker/credential_manager/errors.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from requests import RequestException, Response
+
+
 class DockerLoginFailed(Exception):
     """We failed to login to Docker from some reason."""
 
@@ -6,3 +11,19 @@ class DockerLoginFailed(Exception):
 
 class InvalidDockerCommand(Exception):
     """The Docker command is misconfigured."""
+
+
+class CallbackFailed(Exception):
+    """
+    Calling a registry credentials callback failed.
+    """
+
+    def get_callback_response(self) -> Optional[Response]:
+        """
+        Attempt to reach into the inner exception to get the response object returned by the callback.
+        """
+        if isinstance(self.__cause__, RequestException):
+            response = self.__cause__.response
+            if isinstance(response, Response):
+                return response
+        return None

--- a/laituri/docker/credential_manager/errors.py
+++ b/laituri/docker/credential_manager/errors.py
@@ -2,18 +2,20 @@ from typing import Optional
 
 from requests import RequestException, Response
 
+from laituri.errors import LaituriError
 
-class DockerLoginFailed(Exception):
+
+class DockerLoginFailed(LaituriError):
     """We failed to login to Docker from some reason."""
 
     pass
 
 
-class InvalidDockerCommand(Exception):
+class InvalidDockerCommand(LaituriError):
     """The Docker command is misconfigured."""
 
 
-class CallbackFailed(Exception):
+class CallbackFailed(LaituriError):
     """
     Calling a registry credentials callback failed.
     """

--- a/laituri/docker/credential_manager/registry_credentials_callback_v1.py
+++ b/laituri/docker/credential_manager/registry_credentials_callback_v1.py
@@ -6,6 +6,7 @@ from requests.utils import default_headers
 
 import laituri
 from laituri.docker.credential_manager.docker_v1 import docker_v1_credential_manager
+from laituri.docker.credential_manager.errors import CallbackFailed
 from laituri.utils.retry import retry
 
 
@@ -16,7 +17,11 @@ def registry_credentials_callback_v1_credential_manager(
     registry_credentials: Dict,
     log_status: Callable
 ):
-    docker_credentials = fetch_docker_credentials(registry_credentials)
+    try:
+        docker_credentials = fetch_docker_credentials(registry_credentials)
+    except Exception as exc:
+        raise CallbackFailed(f"Credential callback failed: {exc}") from exc
+
     with docker_v1_credential_manager(image=image, registry_credentials=docker_credentials, log_status=log_status):
         yield
 

--- a/laituri/errors.py
+++ b/laituri/errors.py
@@ -1,0 +1,2 @@
+class LaituriError(Exception):
+    """Base class for Laituri errors."""


### PR DESCRIPTION
This makes it easier for downstream users to figure out that the context manager is throwing because of an error calling the callback.