### PR TITLE
Small fixes & embetterments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2020 Valohai
+Copyright (c) 2020-2022 Valohai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/laituri/docker/credential_manager/docker_v1.py
+++ b/laituri/docker/credential_manager/docker_v1.py
@@ -26,8 +26,10 @@ def docker_v1_credential_manager(
         )
     except DockerLoginFailed as dlf:
         raise DockerLoginFailed(f'Failed Docker login to {domain}: {str(dlf)}') from dlf
-    yield
-    docker_logout(domain)
+    try:
+        yield
+    finally:
+        docker_logout(domain)
 
 
 def docker_login(domain: str, username: str, password: str) -> bool:

--- a/laituri/docker/credential_manager/docker_v1.py
+++ b/laituri/docker/credential_manager/docker_v1.py
@@ -51,7 +51,7 @@ def docker_login(domain: str, username: str, password: str) -> bool:
         '--password-stdin',
         domain,
     ]
-    log.info(f"Running `{' '.join(args)}`")
+    log.debug(f"Running `{' '.join(args)}`")
     proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     try:
         cmd_input = (password + '\n').encode('utf-8')
@@ -72,7 +72,7 @@ def docker_logout(domain: str) -> None:
         domain = 'https://index.docker.io/v1/'
 
     try:
-        log.info(f'Running `docker logout {domain}`')
+        log.debug(f'Running `docker logout {domain}`')
         subprocess.check_call([
             get_docker_command(),
             'logout',

--- a/laituri/docker/credential_manager/errors.py
+++ b/laituri/docker/credential_manager/errors.py
@@ -2,3 +2,7 @@ class DockerLoginFailed(Exception):
     """We failed to login to Docker from some reason."""
 
     pass
+
+
+class InvalidDockerCommand(Exception):
+    """The Docker command is misconfigured."""

--- a/laituri_tests/mock_process.py
+++ b/laituri_tests/mock_process.py
@@ -7,9 +7,9 @@ def create_mock_popen():
 
     def popen_mock(args, **kwargs):
         # make all known call types automatically succeed
-        if args[1] == 'docker' and (args[2] == 'login' or args[2] == 'logout'):
+        if args[0].endswith('docker') and args[1] in ('login', 'logout'):
             return create_mock_process()
-        raise NotImplementedError('not sure how to mock this process')
+        raise NotImplementedError(f'not sure how to mock this process: {args}')
 
     mock = Mock(wraps=popen_mock)
     return mock

--- a/laituri_tests/test_docker_v1.py
+++ b/laituri_tests/test_docker_v1.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from laituri.docker.credential_manager import get_credential_manager
-from laituri.docker.credential_manager.errors import DockerLoginFailed
+from laituri.docker.credential_manager.errors import DockerLoginFailed, InvalidDockerCommand
 from laituri_tests.mock_data import EXAMPLE_IMAGES
 from laituri_tests.mock_process import create_mock_popen, create_mock_process
 
@@ -23,7 +23,7 @@ def test_login_timeout(mocker):
 
     def popen_mock(args, **kwargs):
         # force the login processes to raise TimeoutExpired
-        if args[2] == 'login':
+        if args[1] == 'login':
             mock_process = create_mock_process()
             mock_process.communicate.side_effect = subprocess.TimeoutExpired(cmd='docker login', timeout=30)
             return mock_process
@@ -60,7 +60,7 @@ def test_that_logout_error_doesnt_crash(mocker):
 
     def check_call_mock(args, **kwargs):
         # force logout processes to error out
-        if args[2] == 'logout':
+        if args[1] == 'logout':
             raise subprocess.CalledProcessError(returncode=1, cmd='docker logout', output=b'')
         return create_mock_process()
 
@@ -96,21 +96,13 @@ def test_changing_settings(mocker):
     my_action = mocker.Mock()
 
     # accept all subprocess calls that use the default 'docker' command
-    mocker.patch(
-        'subprocess.Popen',
-        wraps=lambda args, **kwargs: create_mock_process() if args[1] == 'docker' else None,
-    )
+    mocker.patch('subprocess.Popen', new_callable=create_mock_popen)
     with get_credential_manager(image=EXAMPLE_IMAGES[0], registry_credentials=VALID_DOCKER_CREDENTIALS):
         my_action()
-    my_action.call_count = 1
 
     # modify the settings and accept only subprocess calls that use the modified command
     custom_command = 'modified-docker'
     mocker.patch('laituri.settings.DOCKER_COMMAND', custom_command)
-    mocker.patch(
-        'subprocess.Popen',
-        wraps=lambda args, **kwargs: create_mock_process() if args[1] == custom_command else None
-    )
-    with get_credential_manager(image=EXAMPLE_IMAGES[0], registry_credentials=VALID_DOCKER_CREDENTIALS):
-        my_action()
-    my_action.call_count = 2
+    with pytest.raises(InvalidDockerCommand):
+        with get_credential_manager(image=EXAMPLE_IMAGES[0], registry_credentials=VALID_DOCKER_CREDENTIALS):
+            my_action()


### PR DESCRIPTION
* Makes logging a little less verbose
* Use shutil.which to find docker (to avoid one needless `/usr/bin/env`)
* Ensures docker_logout gets called even if an exception occurs