### PR TITLE
Allow using credentials for non-registry-domain images

### DIFF
--- a/laituri/docker/credential_manager/docker_v1.py
+++ b/laituri/docker/credential_manager/docker_v1.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict
 
 from laituri import settings
 from laituri.docker.credential_manager.errors import DockerLoginFailed, InvalidDockerCommand
+from laituri.utils.images import get_image_domain
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +18,8 @@ def docker_v1_credential_manager(
     registry_credentials: Dict,
     log_status: Callable
 ):
-    domain = image.split('/')[0]
+    # If image looks like a dockerhub image, use docker.io as the registry domain
+    domain = get_image_domain(image)
     try:
         docker_login(
             domain=str(domain),

--- a/laituri/utils/images.py
+++ b/laituri/utils/images.py
@@ -1,0 +1,2 @@
+def get_image_domain(image):
+    return image.split('/')[0] if image.count('/') > 1 else 'docker.io'

--- a/laituri/utils/images.py
+++ b/laituri/utils/images.py
@@ -1,2 +1,2 @@
-def get_image_domain(image):
+def get_image_domain(image: str) -> str:
     return image.split('/')[0] if image.count('/') > 1 else 'docker.io'

--- a/laituri_tests/test_credential_managers.py
+++ b/laituri_tests/test_credential_managers.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from laituri.docker.credential_manager import get_credential_manager
+from laituri.utils.images import get_image_domain
 from laituri_tests.mock_data import EXAMPLE_IMAGES
 from laituri_tests.mock_process import create_mock_popen
 from laituri_tests.test_docker_v1 import VALID_DOCKER_CREDENTIALS
@@ -29,6 +30,8 @@ def test_login_with_valid_credentials(mocker, requests_mock, image: str, credent
         requests_mock.post(VALID_CALLBACK_CREDENTIALS['url'], json=VALID_CALLBACK_RESPONSE)
     with get_credential_manager(image=image, registry_credentials=credentials):
         assert mock_popen.call_count == 1  # login
+        args = mock_popen.call_args[0][0]
+        assert args[-1] == get_image_domain(image)
         my_action()
     assert mock_popen.call_count == 2  # login + logout
     my_action.assert_called_once_with()

--- a/laituri_tests/test_utils.py
+++ b/laituri_tests/test_utils.py
@@ -1,0 +1,6 @@
+from laituri.utils.images import get_image_domain
+
+
+def test_get_image_domain():
+    assert get_image_domain("python:3.6") == "docker.io"
+    assert get_image_domain("gcr.io/google-containers/busybox:latest") == "gcr.io"


### PR DESCRIPTION
In that case, use docker.io as a domain.

Previously there has been no login for images like `python` or `example/hello:latest`, but since docker hub now has pull rate limits, let's make that possible so users with paid accounts can pull more.

Refs valohai/roi#3864