### PR TITLE
Image domain corner-case fixes

### DIFF
--- a/laituri/docker/credential_manager/docker_v1.py
+++ b/laituri/docker/credential_manager/docker_v1.py
@@ -7,7 +7,7 @@ from typing import Iterator
 from laituri import settings
 from laituri.docker.credential_manager.errors import DockerLoginFailed, InvalidDockerCommand
 from laituri.types import LogStatusCallable, RegistryCredentialsDict
-from laituri.utils.images import get_image_domain
+from laituri.utils.images import get_image_hostname
 
 log = logging.getLogger(__name__)
 
@@ -20,19 +20,19 @@ def docker_v1_credential_manager(
     log_status: LogStatusCallable,
 ) -> Iterator[None]:
     # If image looks like a dockerhub image, use docker.io as the registry domain
-    domain = get_image_domain(image)
+    hostname = get_image_hostname(image)
     try:
         docker_login(
-            domain=str(domain),
+            domain=str(hostname),
             username=str(registry_credentials['username']),
             password=str(registry_credentials['password']),
         )
     except DockerLoginFailed as dlf:
-        raise DockerLoginFailed(f'Failed Docker login to {domain}: {str(dlf)}') from dlf
+        raise DockerLoginFailed(f'Failed Docker login to {hostname}: {str(dlf)}') from dlf
     try:
         yield
     finally:
-        docker_logout(domain)
+        docker_logout(hostname)
 
 
 def get_docker_command() -> str:

--- a/laituri/utils/images.py
+++ b/laituri/utils/images.py
@@ -1,4 +1,4 @@
-def get_image_domain(image: str) -> str:
+def get_image_hostname(image: str) -> str:
     if image.count('/'):
         first = image.split('/')[0]
         if '.' in first or ':' in first or first == 'localhost':

--- a/laituri/utils/images.py
+++ b/laituri/utils/images.py
@@ -1,2 +1,6 @@
 def get_image_domain(image: str) -> str:
-    return image.split('/')[0] if image.count('/') > 1 else 'docker.io'
+    if image.count('/'):
+        first = image.split('/')[0]
+        if '.' in first or ':' in first or first == 'localhost':
+            return first
+    return 'docker.io'

--- a/laituri_tests/test_credential_managers.py
+++ b/laituri_tests/test_credential_managers.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from laituri.docker.credential_manager import get_credential_manager
-from laituri.utils.images import get_image_domain
+from laituri.utils.images import get_image_hostname
 from laituri_tests.mock_data import EXAMPLE_IMAGES
 from laituri_tests.mock_process import create_mock_popen
 from laituri_tests.test_docker_v1 import VALID_DOCKER_CREDENTIALS
@@ -31,7 +31,7 @@ def test_login_with_valid_credentials(mocker, requests_mock, image: str, credent
     with get_credential_manager(image=image, registry_credentials=credentials):
         assert mock_popen.call_count == 1  # login
         args = mock_popen.call_args[0][0]
-        assert args[-1] == get_image_domain(image)
+        assert args[-1] == get_image_hostname(image)
         my_action()
     assert mock_popen.call_count == 2  # login + logout
     my_action.assert_called_once_with()

--- a/laituri_tests/test_utils.py
+++ b/laituri_tests/test_utils.py
@@ -3,4 +3,8 @@ from laituri.utils.images import get_image_domain
 
 def test_get_image_domain():
     assert get_image_domain("python:3.6") == "docker.io"
+    assert get_image_domain("tensorflow/tensorflow:latest") == "docker.io"
+    assert get_image_domain("docker.io/tensorflow/tensorflow:latest") == "docker.io"
+    assert get_image_domain("my.io/tensorflow:latest") == "my.io"
+    assert get_image_domain("localhost:500/tensorflow:latest") == "localhost:500"
     assert get_image_domain("gcr.io/google-containers/busybox:latest") == "gcr.io"

--- a/laituri_tests/test_utils.py
+++ b/laituri_tests/test_utils.py
@@ -1,10 +1,10 @@
-from laituri.utils.images import get_image_domain
+from laituri.utils.images import get_image_hostname
 
 
-def test_get_image_domain():
-    assert get_image_domain("python:3.6") == "docker.io"
-    assert get_image_domain("tensorflow/tensorflow:latest") == "docker.io"
-    assert get_image_domain("docker.io/tensorflow/tensorflow:latest") == "docker.io"
-    assert get_image_domain("my.io/tensorflow:latest") == "my.io"
-    assert get_image_domain("localhost:500/tensorflow:latest") == "localhost:500"
-    assert get_image_domain("gcr.io/google-containers/busybox:latest") == "gcr.io"
+def test_get_image_hostname():
+    assert get_image_hostname("python:3.6") == "docker.io"
+    assert get_image_hostname("tensorflow/tensorflow:latest") == "docker.io"
+    assert get_image_hostname("docker.io/tensorflow/tensorflow:latest") == "docker.io"
+    assert get_image_hostname("my.io/tensorflow:latest") == "my.io"
+    assert get_image_hostname("localhost:500/tensorflow:latest") == "localhost:500"
+    assert get_image_hostname("gcr.io/google-containers/busybox:latest") == "gcr.io"


### PR DESCRIPTION
As reported by @ruksi, there are some corner cases in which laituri doesn't resolve the image hostname correctly:
- A private registry image is in the form `hostname/name:tag` instead of `hostname/owner/name:tag`
- Images have localhost as their registry hostname

This fix should correct those cases. 