### PR TITLE
Retry more when callback-fetching Docker credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.6'
+          - '3.7'
           - '3.10'
     steps:
       - name: 'Set up Python ${{ matrix.python-version }}'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/valohai/laituri/actions/workflows/ci.yml/badge.svg)](https://github.com/valohai/laituri/actions/workflows/ci.yml)[![codecov](https://codecov.io/gh/valohai/laituri/branch/master/graph/badge.svg)](https://codecov.io/gh/valohai/laituri)
 
-`laituri` is a set of Docker-related Python snippets used at [Valohai](https://valohai.com/). You can use it with Python >= 3.6.
+`laituri` is a set of Docker-related Python snippets used at [Valohai](https://valohai.com/). You can use it with Python >= 3.7.
 
 ## Usage
 

--- a/laituri/docker/credential_manager/registry_credentials_callback_v1.py
+++ b/laituri/docker/credential_manager/registry_credentials_callback_v1.py
@@ -27,7 +27,7 @@ def registry_credentials_callback_v1_credential_manager(
         yield
 
 
-@retry()
+@retry(tries=10)
 def fetch_docker_credentials(request_info: Dict[str, Any]) -> RegistryCredentialsDict:
     headers = default_headers()  # type: ignore[no-untyped-call]
     headers['User-Agent'] = f'{headers.get("User-Agent")} laituri/{laituri.__version__}'

--- a/laituri/utils/retry.py
+++ b/laituri/utils/retry.py
@@ -12,10 +12,11 @@ def retry(*, tries: int = 5, max_delay: float = 32) -> Callable[[T], T]:
     """
 
     def inner_retry(func: T) -> T:
+
         @wraps(func)
         def wrapped_func(*args, **kwargs):  # type: ignore
             attempt = 1
-            while attempt < tries:
+            while attempt <= tries:
                 try:
                     return func(*args, **kwargs)
                 except Exception:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 
 [options]
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 install_requires =
     requests>=2.23,<3


### PR DESCRIPTION
+ fix off-by-one error
+ increase the retry count from 5 (effectively was 4) to 10
+ run CI and mark the package as 3.7+ only (3.6 is EOL and unavailable)

so the fetch credentials retrying changes:

+ __old:__ 4 times over ~15 seconds (1 + 2 + 4 + 8 waits, because the off-by-one error)
+ __new:__ 10 times over ~3 minutes 11 seconds (1 + 2 + 4 + 8 + 16 + 32 + 32 + 32 + 32 + 32 waits)

so it will try roughly __13 times longer__ than it used to, with very generous wait times