### PR TITLE
Allow customizing how many times it tries to do auth credential callback

### DIFF
--- a/laituri/docker/credential_manager/__init__.py
+++ b/laituri/docker/credential_manager/__init__.py
@@ -14,6 +14,7 @@ def get_credential_manager(
     image: str,
     registry_credentials: Optional[RegistryCredentialsDict] = None,
     log_status: LogStatusCallable = _noop_log_status,
+    auth_tries: int = 5,
 ) -> CredentialManager:
     """
     Get a credential context manager object based on the registry credentials dictionary passed in.
@@ -24,6 +25,7 @@ def get_credential_manager(
     :param image: full Docker image name, including the registry domain and tag if applicable
     :param registry_credentials: optional {type, version, username, password} dict for registry login
     :param log_status: optional function to use for user-facing status logging
+    :param auth_tries: number of times to try authentication in case it fails
     :raises DockerLoginFailed
     :return: ContextManager
     """
@@ -38,6 +40,7 @@ def get_credential_manager(
             image=image,
             registry_credentials=registry_credentials,
             log_status=log_status,
+            auth_tries=auth_tries,
         )
 
     log_status(f'Unable to parse {credentials_type} version {version} registry credentials; upcoming action may fail.')

--- a/laituri/docker/credential_manager/docker_v1.py
+++ b/laituri/docker/credential_manager/docker_v1.py
@@ -18,6 +18,7 @@ def docker_v1_credential_manager(
     image: str,
     registry_credentials: RegistryCredentialsDict,
     log_status: LogStatusCallable,
+    auth_tries: int,
 ) -> Iterator[None]:
     # If image looks like a dockerhub image, use docker.io as the registry domain
     hostname = get_image_hostname(image)

--- a/laituri/docker/credential_manager/dummy.py
+++ b/laituri/docker/credential_manager/dummy.py
@@ -10,6 +10,7 @@ def dummy_credential_manager(
     image: str,
     registry_credentials: RegistryCredentialsDict,
     log_status: LogStatusCallable,
+    auth_tries: int,
 ) -> Iterator[None]:
     """
     Credential context manager that does nothing.
@@ -23,4 +24,9 @@ def get_dummy_credential_manager() -> ContextManager[None]:
     """
     Construct a dummy credential manager without having to think about arguments.
     """
-    return dummy_credential_manager(image="", registry_credentials={}, log_status=lambda s: None)
+    return dummy_credential_manager(
+        image="",
+        registry_credentials={},
+        log_status=lambda s: None,
+        auth_tries=1,
+    )

--- a/laituri/docker/credential_manager/ecr_with_role_v1.py
+++ b/laituri/docker/credential_manager/ecr_with_role_v1.py
@@ -13,6 +13,7 @@ def ecr_with_role_v1_credential_manager(
     image: str,
     registry_credentials: RegistryCredentialsDict,
     log_status: LogStatusCallable,
+    auth_tries: int,
 ) -> Iterator[None]:
     from boto3 import Session
     role_name = registry_credentials['role_name']
@@ -35,7 +36,12 @@ def ecr_with_role_v1_credential_manager(
     except Exception as exc:
         raise ECRLoginFailed(f"Role based docker credentials fetch failed: {exc}") from exc
 
-    with docker_v1_credential_manager(image=image, registry_credentials=docker_credentials, log_status=log_status):
+    with docker_v1_credential_manager(
+        image=image,
+        registry_credentials=docker_credentials,
+        log_status=log_status,
+        auth_tries=auth_tries,
+    ):
         yield
 
 

--- a/laituri/docker/credential_manager/registry_credentials_callback_v1.py
+++ b/laituri/docker/credential_manager/registry_credentials_callback_v1.py
@@ -17,14 +17,20 @@ def registry_credentials_callback_v1_credential_manager(
     image: str,
     registry_credentials: RegistryCredentialsDict,
     log_status: LogStatusCallable,
+    auth_tries: int,
 ) -> Iterator[None]:
-    retrying_fetch_docker_credentials = make_retrying(fetch_docker_credentials, tries=10)
+    retrying_fetch_docker_credentials = make_retrying(fetch_docker_credentials, tries=auth_tries)
     try:
         docker_credentials = retrying_fetch_docker_credentials(registry_credentials)
     except Exception as exc:
         raise CallbackFailed(f"Credential callback failed: {exc}") from exc
 
-    with docker_v1_credential_manager(image=image, registry_credentials=docker_credentials, log_status=log_status):
+    with docker_v1_credential_manager(
+        image=image,
+        registry_credentials=docker_credentials,
+        log_status=log_status,
+        auth_tries=auth_tries,
+    ):
         yield
 
 

--- a/laituri/utils/retry.py
+++ b/laituri/utils/retry.py
@@ -16,7 +16,7 @@ def retry(*, tries: int = 5, max_delay: float = 32) -> Callable[[T], T]:
         @wraps(func)
         def wrapped_func(*args, **kwargs):  # type: ignore
             attempt = 1
-            while attempt <= tries:
+            while attempt < tries:
                 try:
                     return func(*args, **kwargs)
                 except Exception:

--- a/laituri/utils/retry.py
+++ b/laituri/utils/retry.py
@@ -18,6 +18,9 @@ def retry(*, tries: int = 5, max_delay: float = 32) -> Callable[[T], T]:
 
 
 def make_retrying(func: T, tries: int = 5, max_delay: float = 32) -> T:
+    if tries < 1:
+        raise ValueError(f'tries must be >= 1, got {tries}')
+
     @wraps(func)
     def wrapped_func(*args, **kwargs):  # type: ignore
         attempt = 1

--- a/laituri/utils/retry.py
+++ b/laituri/utils/retry.py
@@ -12,22 +12,25 @@ def retry(*, tries: int = 5, max_delay: float = 32) -> Callable[[T], T]:
     """
 
     def inner_retry(func: T) -> T:
-
-        @wraps(func)
-        def wrapped_func(*args, **kwargs):  # type: ignore
-            attempt = 1
-            while attempt < tries:
-                try:
-                    return func(*args, **kwargs)
-                except Exception:
-                    delay = (2 ** (attempt - 1))  # 1, 2, 4, 8, 16, 32...
-                    delay += random.random()  # a tiny bit of random for desynchronizing multiple potential users
-                    delay = min(delay, max_delay)
-                    time.sleep(delay)
-                    attempt += 1
-            # and finally, just try one more time but let any exceptions bubble up
-            return func(*args, **kwargs)
-
-        return cast(T, wrapped_func)
+        return make_retrying(func, tries=tries, max_delay=max_delay)
 
     return inner_retry
+
+
+def make_retrying(func: T, tries: int = 5, max_delay: float = 32) -> T:
+    @wraps(func)
+    def wrapped_func(*args, **kwargs):  # type: ignore
+        attempt = 1
+        while attempt < tries:
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                delay = (2 ** (attempt - 1))  # 1, 2, 4, 8, 16, 32...
+                delay += random.random()  # a tiny bit of random for desynchronizing multiple potential users
+                delay = min(delay, max_delay)
+                time.sleep(delay)
+                attempt += 1
+        # and finally, just try one more time but let any exceptions bubble up
+        return func(*args, **kwargs)
+
+    return cast(T, wrapped_func)

--- a/laituri_tests/test_retry.py
+++ b/laituri_tests/test_retry.py
@@ -1,0 +1,45 @@
+import pytest
+
+from laituri.utils.retry import retry
+
+
+class TestRetry:
+
+    @pytest.fixture(autouse=True)
+    def disable_sleep(self, mocker):
+        return mocker.patch('time.sleep')  # removes retry delays for testing
+
+    def test_works_if_no_exception(self, mocker):
+        my_action = mocker.Mock()
+
+        @retry()
+        def my_retryable_action():
+            my_action()
+
+        my_retryable_action()
+        assert my_action.call_count == 1
+
+    def test_default_attempt_count(self, mocker):
+        my_action = mocker.Mock(side_effect=Exception('boom!'))
+
+        @retry()
+        def my_retryable_action():
+            my_action()
+
+        with pytest.raises(Exception, match='boom!'):
+            my_retryable_action()
+
+        assert my_action.call_count == 5
+
+
+    def test_custom_attempt_count(self, mocker):
+        my_action = mocker.Mock(side_effect=Exception('pow!'))
+
+        @retry(tries=11)
+        def my_retryable_action():
+            my_action()
+
+        with pytest.raises(Exception, match='pow!'):
+            my_retryable_action()
+
+        assert my_action.call_count == 11

--- a/laituri_tests/test_retry.py
+++ b/laituri_tests/test_retry.py
@@ -1,6 +1,6 @@
 import pytest
 
-from laituri.utils.retry import retry
+from laituri.utils.retry import make_retrying, retry
 
 
 class TestRetry:
@@ -9,17 +9,17 @@ class TestRetry:
     def disable_sleep(self, mocker):
         return mocker.patch('time.sleep')  # removes retry delays for testing
 
-    def test_works_if_no_exception(self, mocker):
+    def test_decorator_works(self, mocker):
         my_action = mocker.Mock()
 
         @retry()
         def my_retryable_action():
-            my_action()
+            my_action('AWESOME', a=1)
 
         my_retryable_action()
-        assert my_action.call_count == 1
+        my_action.assert_called_once_with('AWESOME', a=1)
 
-    def test_default_attempt_count(self, mocker):
+    def test_decorator_default_tries(self, mocker):
         my_action = mocker.Mock(side_effect=Exception('boom!'))
 
         @retry()
@@ -31,8 +31,7 @@ class TestRetry:
 
         assert my_action.call_count == 5
 
-
-    def test_custom_attempt_count(self, mocker):
+    def test_decorator_custom_tries(self, mocker):
         my_action = mocker.Mock(side_effect=Exception('pow!'))
 
         @retry(tries=11)
@@ -43,3 +42,23 @@ class TestRetry:
             my_retryable_action()
 
         assert my_action.call_count == 11
+
+    def test_wrapper_works(self, mocker):
+        my_action = mocker.Mock()
+        my_retrying_action = make_retrying(my_action)
+        my_retrying_action('GREAT', b=2)
+        my_action.assert_called_once_with('GREAT', b=2)
+
+    def test_wrapper_default_tries(self, mocker):
+        my_action = mocker.Mock(side_effect=Exception('bang!'))
+        my_retrying_action = make_retrying(my_action)
+        with pytest.raises(Exception, match='bang!'):
+            my_retrying_action()
+        assert my_action.call_count == 5
+
+    def test_wrapper_custom_tries(self, mocker):
+        my_action = mocker.Mock(side_effect=Exception('oof!'))
+        my_retrying_action = make_retrying(my_action, tries=3)
+        with pytest.raises(Exception, match='oof!'):
+            my_retrying_action()
+        assert my_action.call_count == 3

--- a/laituri_tests/test_retry.py
+++ b/laituri_tests/test_retry.py
@@ -62,3 +62,9 @@ class TestRetry:
         with pytest.raises(Exception, match='oof!'):
             my_retrying_action()
         assert my_action.call_count == 3
+
+    @pytest.mark.parametrize('tries', (0, -1))
+    def test_invalid_tries(self, mocker, tries):
+        my_action = mocker.Mock()
+        with pytest.raises(ValueError, match='tries must be >= 1'):
+            make_retrying(my_action, tries=tries)


### PR DESCRIPTION
Allows specifying `auth_tries` to the credential managers which currently controls just how many times it does the credential callback but we could use it for other auth retrying if we feel like it.

Didn't want to add `callback_tries` to just control that one aspect of authentication (the callback count), but could be argued either way.